### PR TITLE
Implement support for references within StringInput

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -6,7 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 /// A `trait` that defines an input for a `Parser`.
-pub trait Input {
+pub trait Input<'a> {
     /// Returns length of an `Input`.
     fn len(&self) -> usize;
 
@@ -20,7 +20,7 @@ pub trait Input {
     fn set_pos(&mut self, pos: usize);
 
     /// Slices an `Input`.
-    fn slice(&self, start: usize, end: usize) -> &str;
+    fn slice(&self, start: usize, end: usize) -> &'a str;
 
     /// Returns the line and column of a position for an `Input`.
     fn line_col(&self, pos: usize) -> (usize, usize);

--- a/src/inputs/string_input.rs
+++ b/src/inputs/string_input.rs
@@ -48,7 +48,7 @@ impl<'a> StringInput<'a> {
     }
 }
 
-impl<'a> Input for StringInput<'a> {
+impl<'a> Input<'a> for StringInput<'a> {
     #[inline]
     fn len(&self) -> usize {
         self.string.len()
@@ -70,7 +70,7 @@ impl<'a> Input for StringInput<'a> {
     }
 
     #[inline]
-    fn slice(&self, start: usize, end: usize) -> &str {
+    fn slice(&self, start: usize, end: usize) -> &'a str {
         &self.string[start..end]
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,7 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 /// A `trait` that defines a parser.
-pub trait Parser {
+pub trait Parser<'a> {
     type Rule;
     type Token;
 
@@ -52,7 +52,7 @@ pub trait Parser {
     fn reset(&mut self);
 
     /// Slices a `Parser`'s `Input`.
-    fn slice_input(&self, start: usize, end: usize) -> &str;
+    fn slice_input(&self, start: usize, end: usize) -> &'a str;
 
     /// Returns the queue of all matched `Token`s.
     fn queue(&self) -> &Vec<Self::Token>;

--- a/tests/sentence_lifetime.rs
+++ b/tests/sentence_lifetime.rs
@@ -1,0 +1,43 @@
+// pest. Elegant, efficient grammars
+// Copyright (C) 2016  Dragoș Tiselice
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#[macro_use]
+extern crate pest;
+
+use std::collections::LinkedList;
+
+use pest::prelude::*;
+
+#[derive(Debug, PartialEq)]
+pub enum Node<'a> {
+    Sentence(&'a str),
+}
+
+impl_rdp! {
+    grammar! {
+        word     =  { letter* }
+        letter   =  { ['a'..'z'] }
+    }
+
+    process! {
+        main(&self) -> Node<'n> {
+            (&w: word) => Node::Sentence(w)
+        }
+    }
+}
+
+#[test]
+fn word() {
+    let file = "abc def";
+    let result = {
+        let mut parser = Rdp::new(StringInput::new(&file));
+
+        assert!(parser.word());
+        parser.process()
+    };
+    assert_eq!(result, Node::Sentence("abc"));
+}


### PR DESCRIPTION
This allows the usage of an in-memory string, without implicit copying during processing.